### PR TITLE
Added support for signature copying

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,11 @@ start with ``mock_``, while the constructor arguments don't.
     object the tracker will be notified. Otherwise attribute sets are
     silent, and only calls trigger notification.
 
+``copy_signature_of``:
+    If given, the function or object signature will be copied to the
+    mock object. This can be useful when testing codes that rely
+    on metaprogramming.
+
 So to create an object that always raises ValueError, do::
 
     >>> dummy_module = Mock('mylibrary')


### PR DESCRIPTION
Made this modification because I had a code whose minimock couldn't help me easily:
```python
def parse_varargs(f, *args, **kwargs):
    return inspect.signature(f).bind(*args, **kwargs).arguments
```
The code above represents a varargs parser I used in decorators. However, because the function `f`, already mocked, was passed to it, and because its signature was different, then `parse_varargs` output did not work as expected.
```python
>>> def parse_varargs(f, *args, **kwargs):
...     return inspect.signature(f).bind(*args, **kwargs).arguments

>>> def foo(a, b, c=4):
...     pass

>>> mock('foo', copy_signature=True)
>>> parse_varargs(foo, 3, 4, c=5)
{'a': 3, 'b': 4, 'c': 5}
>>> restore()

>>> mock('foo')
>>> parse_varargs(foo, 3, 4, c=5)
Traceback (most recent call last):
  ...
TypeError: unexpected object <Mock 0x1f91fb498e0 foo.__signature__> in __signature__ attribute
>>> restore()
```
I hope this pr can improve this wonderful lib that helped me a lot!